### PR TITLE
Deserialization of ics into Event Structs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: elixir
-
+language: elixir 
 elixir:
-  - 1.2.0
+  - 1.3.2
 
 otp_release:
   - 18.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.1.0
+  - 1.2.0
 
 otp_release:
   - 18.0

--- a/lib/icalendar.ex
+++ b/lib/icalendar.ex
@@ -5,6 +5,7 @@ defmodule ICalendar do
 
   defstruct events: []
   defdelegate to_ics(events), to: ICalendar.Serialize
+  defdelegate from_ics(events), to: ICalendar.Deserialize
 end
 
 defimpl ICalendar.Serialize, for: ICalendar do

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -2,70 +2,15 @@ defprotocol ICalendar.Deserialize do
   def from_ics(ics)
 end
 
+alias ICalendar.Deserialize
+
 defimpl ICalendar.Deserialize, for: BitString do
-  alias ICalendar.Event
+  alias ICalendar.Util.Deserialize
 
   def from_ics(ics) do
     ics
     |> String.trim
     |> String.split("\n")
-    |> Enum.map(&retrieve_kvs/1)
-    |> Enum.reduce(%Event{}, &build_event/2)
+    |> Deserialize.build_event
   end
-
-  def retrieve_kvs(line) do
-    [key, value] = String.split(line, ":")
-    {String.upcase(key), value}
-  end
-
-  def build_event({"DESCRIPTION", description}, acc) do
-    %{acc | description: description}
-  end
-  def build_event({"DTSTART", dtstart}, acc) do
-    %{acc | dtstart: to_date(dtstart)}
-  end
-  def build_event({"DTEND", dtend}, acc), do: %{acc | dtend: to_date(dtend)}
-  def build_event({"SUMMARY", summary}, acc), do: %{acc | summary: summary}
-  def build_event(_, acc), do: acc
-
-  def to_date(date_string) do
-
-    [date, time] =
-      date_string
-      |> String.upcase
-      |> String.split(["T", "Z"], trim: true)
-
-    year =
-      date
-      |> String.slice(0..3)
-      |> String.to_integer
-
-    month =
-      date
-      |> String.slice(4..5)
-      |> String.to_integer
-
-    day =
-      date
-      |> String.slice(6..7)
-      |> String.to_integer
-
-    hour =
-      time
-      |> String.slice(0..1)
-      |> String.to_integer
-
-    minute =
-      time
-      |> String.slice(2..3)
-      |> String.to_integer
-
-    second =
-      time
-      |> String.slice(4..5)
-      |> String.to_integer
-
-    {{year, month, day}, {hour, minute, second}}
-  end
-
 end

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -18,10 +18,14 @@ defimpl ICalendar.Deserialize, for: BitString do
     {String.upcase(key), value}
   end
 
-  def build_event({"DESCRIPTION", description}, acc), do: Map.put(acc, :description, description)
-  def build_event({"SUMMARY", summary}, acc), do: Map.put(acc, :summary, summary)
-  def build_event({"DTSTART", dtstart}, acc), do: Map.put(acc, :dtstart, to_date(dtstart))
-  def build_event({"DTEND", dtend}, acc), do: Map.put(acc, :dtend, to_date(dtend))
+  def build_event({"DESCRIPTION", description}, acc) do
+    %{acc | description: description}
+  end
+  def build_event({"DTSTART", dtstart}, acc) do
+    %{acc | dtstart: to_date(dtstart)}
+  end
+  def build_event({"DTEND", dtend}, acc), do: %{acc | dtend: to_date(dtend)}
+  def build_event({"SUMMARY", summary}, acc), do: %{acc | summary: summary}
   def build_event(_, acc), do: acc
 
   def to_date(date_string) do
@@ -31,13 +35,35 @@ defimpl ICalendar.Deserialize, for: BitString do
       |> String.upcase
       |> String.split(["T", "Z"], trim: true)
 
-    year  = String.slice(date, 0..3) |> String.to_integer
-    month = String.slice(date, 4..5) |> String.to_integer
-    day   = String.slice(date, 6..7) |> String.to_integer
+    year =
+      date
+      |> String.slice(0..3)
+      |> String.to_integer
 
-    hour   = String.slice(time, 0..1) |> String.to_integer
-    minute = String.slice(time, 2..3) |> String.to_integer
-    second = String.slice(time, 4..5) |> String.to_integer
+    month =
+      date
+      |> String.slice(4..5)
+      |> String.to_integer
+
+    day =
+      date
+      |> String.slice(6..7)
+      |> String.to_integer
+
+    hour =
+      time
+      |> String.slice(0..1)
+      |> String.to_integer
+
+    minute =
+      time
+      |> String.slice(2..3)
+      |> String.to_integer
+
+    second =
+      time
+      |> String.slice(4..5)
+      |> String.to_integer
 
     {{year, month, day}, {hour, minute, second}}
   end

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -1,0 +1,45 @@
+defprotocol ICalendar.Deserialize do
+  def from_ics(ics)
+end
+
+defimpl ICalendar.Deserialize, for: BitString do
+  alias ICalendar.Event
+
+  def from_ics(ics) do
+    ics
+    |> String.trim # Remove trailing whitespace
+    |> String.split("\n") # Split by line
+    |> Enum.map(&retrieve_kvs/1) # Convert each line into a key-value tuple
+    |> Enum.reduce(%Event{}, &build_event/2) # Convert the tuple into a map
+  end
+
+  def retrieve_kvs(line) do
+    [key, value] = String.split(line, ":")
+    {String.upcase(key), value}
+  end
+
+  def build_event({"DESCRIPTION", description}, acc), do: Map.put(acc, :description, description)
+  def build_event({"SUMMARY", summary}, acc), do: Map.put(acc, :summary, summary)
+  def build_event({"DTSTART", dtstart}, acc), do: Map.put(acc, :dtstart, to_date(dtstart))
+  def build_event({"DTEND", dtend}, acc), do: Map.put(acc, :dtend, to_date(dtend))
+  def build_event(_, acc), do: acc
+
+  def to_date(date_string) do
+
+    [date, time] =
+      date_string
+      |> String.upcase
+      |> String.split(["T", "Z"], trim: true)
+
+    year  = String.slice(date, 0..3) |> String.to_integer
+    month = String.slice(date, 4..5) |> String.to_integer
+    day   = String.slice(date, 6..7) |> String.to_integer
+
+    hour   = String.slice(time, 0..1) |> String.to_integer
+    minute = String.slice(time, 2..3) |> String.to_integer
+    second = String.slice(time, 4..5) |> String.to_integer
+
+    {{year, month, day}, {hour, minute, second}}
+  end
+
+end

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -7,10 +7,10 @@ defimpl ICalendar.Deserialize, for: BitString do
 
   def from_ics(ics) do
     ics
-    |> String.trim # Remove trailing whitespace
-    |> String.split("\n") # Split by line
-    |> Enum.map(&retrieve_kvs/1) # Convert each line into a key-value tuple
-    |> Enum.reduce(%Event{}, &build_event/2) # Convert the tuple into a map
+    |> String.trim
+    |> String.split("\n")
+    |> Enum.map(&retrieve_kvs/1)
+    |> Enum.reduce(%Event{}, &build_event/2)
   end
 
   def retrieve_kvs(line) do

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -24,9 +24,13 @@ defmodule ICalendar.Util.Deserialize do
     %{acc | description: description}
   end
   def parse_attr({"DTSTART", dtstart}, acc) do
-    %{acc | dtstart: to_date(dtstart)}
+    {:ok, timestamp} = to_date(dtstart)
+    %{acc | dtstart: timestamp}
   end
-  def parse_attr({"DTEND", dtend}, acc), do: %{acc | dtend: to_date(dtend)}
+  def parse_attr({"DTEND", dtend}, acc) do
+    {:ok, timestamp} = to_date(dtend)
+    %{acc | dtend: timestamp}
+  end
   def parse_attr({"SUMMARY", summary}, acc), do: %{acc | summary: summary}
   def parse_attr(_, acc), do: acc
 
@@ -36,12 +40,12 @@ defmodule ICalendar.Util.Deserialize do
   It should be able to handle dates from the past:
 
   iex> ICalendar.Util.Deserialize.to_date("19930407T153022Z")
-  {{1993, 4, 7}, {15, 30, 22}}
+  {:ok, {{1993, 4, 7}, {15, 30, 22}}}
 
   As well as the future:
 
   iex>  ICalendar.Util.Deserialize.to_date("39930407T153022Z")
-  {{3993, 4, 7}, {15, 30, 22}}
+  {:ok, {{3993, 4, 7}, {15, 30, 22}}}
 
   And should return nil for incorrect dates:
 
@@ -66,7 +70,7 @@ defmodule ICalendar.Util.Deserialize do
         time = {
           String.to_integer(hour), String.to_integer(minute),
           String.to_integer(second)}
-        {date, time}
+        {:ok, {date, time}}
 
       _ -> {:error, "Timestamp is not in the correct format: #{date_string}"}
     end

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -1,0 +1,77 @@
+defmodule ICalendar.Util.Deserialize do
+  @moduledoc """
+  Deserialize ICalendar Strings into Event structs
+  """
+
+  alias ICalendar.Event
+
+  def build_event(lines) when is_list(lines) do
+    lines
+    |> Enum.map(&retrieve_kvs/1)
+    |> Enum.reduce(%Event{}, &parse_attr/2)
+  end
+
+  @doc ~S"""
+  iex> ICalendar.Util.Deserialize.retrieve_kvs("lorem:ipsum")
+  {"LOREM", "ipsum"}
+  """
+  def retrieve_kvs(line) do
+    [key, value] = String.split(line, ":")
+    {String.upcase(key), value}
+  end
+
+  def parse_attr({"DESCRIPTION", description}, acc) do
+    %{acc | description: description}
+  end
+  def parse_attr({"DTSTART", dtstart}, acc) do
+    %{acc | dtstart: to_date(dtstart)}
+  end
+  def parse_attr({"DTEND", dtend}, acc), do: %{acc | dtend: to_date(dtend)}
+  def parse_attr({"SUMMARY", summary}, acc), do: %{acc | summary: summary}
+  def parse_attr(_, acc), do: acc
+
+  @doc ~S"""
+  iex> ICalendar.Util.Deserialize.to_date("19930407T153022Z")
+  {{1993, 4, 7}, {15, 30, 22}}
+  """
+  def to_date(date_string) do
+
+    [date, time] =
+      date_string
+      |> String.upcase
+      |> String.split(["T", "Z"], trim: true)
+
+    year =
+      date
+      |> String.slice(0..3)
+      |> String.to_integer
+
+    month =
+      date
+      |> String.slice(4..5)
+      |> String.to_integer
+
+    day =
+      date
+      |> String.slice(6..7)
+      |> String.to_integer
+
+    hour =
+      time
+      |> String.slice(0..1)
+      |> String.to_integer
+
+    minute =
+      time
+      |> String.slice(2..3)
+      |> String.to_integer
+
+    second =
+      time
+      |> String.slice(4..5)
+      |> String.to_integer
+
+    {{year, month, day}, {hour, minute, second}}
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ICalendar.Mixfile do
     [
       app: :icalendar,
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps,

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ICalendar.Mixfile do
     [
       app: :icalendar,
       version: @version,
-      elixir: "~> 1.1",
+      elixir: "~> 1.2",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps,

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -1,0 +1,37 @@
+defmodule ICalendar.DeserializeTest do
+  use ExUnit.Case
+
+  alias ICalendar.Event
+
+  test "ICalendar.from_ics/1 with empty icalendar string" do
+    ics = """
+    BEGIN:VEVENT
+    END:VEVENT
+    """
+    assert ICalendar.from_ics(ics) == %Event{
+      dtstart: nil,
+      dtend: nil,
+      summary: nil,
+      description: nil
+    }
+  end
+
+  test "ICalendar.from_ics/1" do
+    ics = """
+    BEGIN:VEVENT
+    DESCRIPTION:Escape from the world. Stare at some water.
+    SUMMARY:Going fishing
+    DTEND:20151224T084500Z
+    DTSTART:20151224T083000Z
+    END:VEVENT
+    """
+    event = ICalendar.from_ics(ics)
+    assert event == %Event{
+      dtstart: {{2015, 12, 24}, {8, 30, 00}},
+      dtend:   {{2015, 12, 24}, {8, 45, 00}},
+      summary: "Going fishing",
+      description: "Escape from the world. Stare at some water."
+    }
+  end
+
+end

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -28,7 +28,7 @@ defmodule ICalendar.DeserializeTest do
     event = ICalendar.from_ics(ics)
     assert event == %Event{
       dtstart: {{2015, 12, 24}, {8, 30, 00}},
-      dtend:   {{2015, 12, 24}, {8, 45, 00}},
+      dtend: {{2015, 12, 24}, {8, 45, 00}}, 
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water."
     }

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -3,19 +3,6 @@ defmodule ICalendar.DeserializeTest do
 
   alias ICalendar.Event
 
-  test "ICalendar.from_ics/1 with empty icalendar string" do
-    ics = """
-    BEGIN:VEVENT
-    END:VEVENT
-    """
-    assert ICalendar.from_ics(ics) == %Event{
-      dtstart: nil,
-      dtend: nil,
-      summary: nil,
-      description: nil
-    }
-  end
-
   test "ICalendar.from_ics/1" do
     ics = """
     BEGIN:VEVENT
@@ -28,10 +15,9 @@ defmodule ICalendar.DeserializeTest do
     event = ICalendar.from_ics(ics)
     assert event == %Event{
       dtstart: {{2015, 12, 24}, {8, 30, 00}},
-      dtend: {{2015, 12, 24}, {8, 45, 00}}, 
+      dtend: {{2015, 12, 24}, {8, 45, 00}},
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water."
     }
   end
-
 end

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -27,4 +27,22 @@ defmodule ICalendar.Util.DeserializeTest do
     }
   end
 
+  test "Handles empty calendars correctly" do
+    event =
+      """
+      BEGIN:VEVENT
+      END:VEVENT
+      """
+      |> String.trim
+      |> String.split("\n")
+      |> Deserialize.build_event
+
+    assert event == %Event{
+      dtstart: nil,
+      dtend: nil,
+      summary: nil,
+      description: nil
+    }
+  end
+
 end

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -1,0 +1,30 @@
+defmodule ICalendar.Util.DeserializeTest do
+  use ExUnit.Case
+  alias ICalendar.Util.Deserialize
+  alias ICalendar.Event
+  doctest ICalendar.Util.Deserialize
+
+  test "Convert iCal String to event Struct" do
+    event =
+      """
+      BEGIN:VEVENT
+      DESCRIPTION:Escape from the world. Stare at some water.
+      SUMMARY:Going fishing
+      DTEND:20151224T084500Z
+      DTSTART:20151224T083000Z
+      END:VEVENT
+      """
+      |> String.trim
+      |> String.split("\n")
+      |> Deserialize.build_event
+
+    assert event == %Event{
+      description: "Escape from the world. Stare at some water.",
+      dtend: {{2015, 12, 24}, {8, 45, 0}},
+      dtstart: {{2015, 12, 24}, {8, 30, 0}},
+      location: nil,
+      summary: "Going fishing"
+    }
+  end
+
+end


### PR DESCRIPTION
This PR is designed to allow for this module to be able to parse ics strings into Event Structs to be read or manipulated in a standard format. This is useful if you are importing ics strings into a database, or if you want to edit an ics.
