### PR TITLE
Datetime and Timezone support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: elixir 
+language: elixir
 elixir:
   - 1.3.2
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ events = [
   },
   %ICalendar.Event{
     summary: "Morning meeting",
-    dtstart: {{2015, 12, 24}, {19, 00, 00}},
-    dtend:   {{2015, 12, 24}, {22, 30, 00}},
+    dtstart: Timex.now,
+    dtend:   Timex.shift(Timex.now, hours: 3),
     description: "A big long meeting with lots of details.",
     location: "456 Boring Street, Toronto ON, Canada"
   },

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -16,7 +16,7 @@ defmodule ICalendar.Util.Deserialize do
   {"LOREM", "ipsum"}
   """
   def retrieve_kvs(line) do
-    [key, value] = String.split(line, ":")
+    [key, value] = String.split(line, ":", parts: 2, trim: true)
     {String.upcase(key), value}
   end
 

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -44,22 +44,26 @@ defmodule ICalendar.Util.Deserialize do
 
   It should be able to handle dates from the past:
 
-      iex> ICalendar.Util.Deserialize.to_date("19930407T153022Z")
-      {:ok, ~N[1993-04-07 15:30:22]}
+      iex> {:ok, date} = ICalendar.Util.Deserialize.to_date("19930407T153022Z")
+      ...> Timex.to_erl(date)
+      {{1993, 4, 7}, {15, 30, 22}}
 
   As well as the future:
 
-      iex>  ICalendar.Util.Deserialize.to_date("39930407T153022Z")
-      {:ok, ~N[3993-04-07 15:30:22]}
+      iex> {:ok, date} = ICalendar.Util.Deserialize.to_date("39930407T153022Z")
+      ...> Timex.to_erl(date)
+      {{3993, 4, 7}, {15, 30, 22}}
 
   And should return nil for incorrect dates:
 
       iex> ICalendar.Util.Deserialize.to_date("1993/04/07")
       {:error, "Expected `1-2 digit month` at line 1, column 5."}
-
   """
   def to_date(date_string) do
-    Timex.parse(date_string, "{YYYY}{0M}{0D}T{h24}{m}{s}Z")
+    # Force UTC until we add native timezone support
+    date_string = date_string <> "UTC"
+    Timex.parse(date_string, "{YYYY}{0M}{0D}T{h24}{m}{s}Z{Zname}")
+  end
 
   @doc ~S"""
 

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -21,7 +21,7 @@ defmodule ICalendar.Util.Deserialize do
   end
 
   def parse_attr({"DESCRIPTION", description}, acc) do
-    %{acc | description: description}
+    %{acc | description: desanitized(description)}
   end
   def parse_attr({"DTSTART", dtstart}, acc) do
     {:ok, timestamp} = to_date(dtstart)
@@ -31,7 +31,9 @@ defmodule ICalendar.Util.Deserialize do
     {:ok, timestamp} = to_date(dtend)
     %{acc | dtend: timestamp}
   end
-  def parse_attr({"SUMMARY", summary}, acc), do: %{acc | summary: summary}
+  def parse_attr({"SUMMARY", summary}, acc) do
+    %{acc | summary: desanitized(summary)}
+  end
   def parse_attr(_, acc), do: acc
 
   @doc ~S"""
@@ -55,5 +57,17 @@ defmodule ICalendar.Util.Deserialize do
   """
   def to_date(date_string) do
     Timex.parse(date_string, "{YYYY}{0M}{0D}T{h24}{m}{s}Z")
+
+  @doc ~S"""
+
+  This function should strip any sanitization that has been applied to content
+  within an iCal string.
+
+  iex> ICalendar.Util.Deserialize.desanitized(~s(lorem\\, ipsum))
+  "lorem, ipsum"
+  """
+  def desanitized(string) do
+    string
+    |> String.replace(~s(\\), "")
   end
 end

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -40,39 +40,20 @@ defmodule ICalendar.Util.Deserialize do
   It should be able to handle dates from the past:
 
       iex> ICalendar.Util.Deserialize.to_date("19930407T153022Z")
-      {:ok, {{1993, 4, 7}, {15, 30, 22}}}
+      {:ok, ~N[1993-04-07 15:30:22]}
 
   As well as the future:
 
-      iex> ICalendar.Util.Deserialize.to_date("39930407T153022Z")
-      {:ok, {{3993, 4, 7}, {15, 30, 22}}}
+      iex>  ICalendar.Util.Deserialize.to_date("39930407T153022Z")
+      {:ok, ~N[3993-04-07 15:30:22]}
 
   And should return nil for incorrect dates:
 
       iex> ICalendar.Util.Deserialize.to_date("1993/04/07")
-      {:error, "Timestamp is not in the correct format: 1993/04/07"}
+      {:error, "Expected `1-2 digit month` at line 1, column 5."}
 
   """
   def to_date(date_string) do
-    date_regex = ~S/(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})/
-    time_regex = ~S/(?<hour>\d{2})(?<minute>\d{2})(?<second>\d{2})/
-    {:ok, regex} = Regex.compile("#{date_regex}T#{time_regex}Z")
-
-    case Regex.named_captures(regex, date_string) do
-      %{
-        "year" => year, "month" => month, "day" => day,
-        "hour" => hour, "minute" => minute, "second" => second} ->
-
-        date = {
-          String.to_integer(year), String.to_integer(month),
-          String.to_integer(day)}
-
-        time = {
-          String.to_integer(hour), String.to_integer(minute),
-          String.to_integer(second)}
-        {:ok, {date, time}}
-
-      _ -> {:error, "Timestamp is not in the correct format: #{date_string}"}
-    end
+    Timex.parse(date_string, "{YYYY}{0M}{0D}T{h24}{m}{s}Z")
   end
 end

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -34,6 +34,9 @@ defmodule ICalendar.Util.Deserialize do
   def parse_attr({"SUMMARY", summary}, acc) do
     %{acc | summary: desanitized(summary)}
   end
+  def parse_attr({"LOCATION", location}, acc) do
+    %{acc | location: desanitized(location)}
+  end
   def parse_attr(_, acc), do: acc
 
   @doc ~S"""

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -13,11 +13,55 @@ defimpl Value, for: BitString do
   end
 end
 
+defimpl Value, for: Tuple do
+  defmacro elem2(x, i1, i2) do
+    quote do
+      unquote(x) |> elem(unquote(i1)) |> elem(unquote(i2))
+    end
+  end
+
+  defmacro is_datetime_tuple(x) do
+    quote do
+      # Year
+      ( unquote(x) |> elem2(0, 0)  |> is_integer) and
+      # Month
+      ( unquote(x) |> elem2(0, 1)  |> is_integer) and
+      ((unquote(x) |> elem2(0, 1)) <= 12) and
+      ((unquote(x) |> elem2(0, 1)) >= 1) and
+      # Day
+      ( unquote(x) |> elem2(0, 2)  |> is_integer) and
+      ((unquote(x) |> elem2(0, 2)) <= 31) and
+      ((unquote(x) |> elem2(0, 2)) >= 1) and
+      # Hour
+      ( unquote(x) |> elem2(1, 0)  |> is_integer) and
+      ((unquote(x) |> elem2(1, 0)) <= 23) and
+      ((unquote(x) |> elem2(1, 0)) >= 0) and
+      # Minute
+      ( unquote(x) |> elem2(1, 1)  |> is_integer) and
+      ((unquote(x) |> elem2(1, 1)) <= 59) and
+      ((unquote(x) |> elem2(1, 1)) >= 0) and
+      # Second
+      ( unquote(x) |> elem2(1, 2)  |> is_integer) and
+      ((unquote(x) |> elem2(1, 2)) <= 60) and
+      ((unquote(x) |> elem2(1, 2)) >= 0)
+    end
+  end
+
+  def to_ics(timestamp) when is_datetime_tuple(timestamp) do
+    Timex.to_datetime(timestamp)
+    |> Value.to_ics
+  end
+
+  def to_ics(x), do: x
+
+end
+
 defimpl Value, for: DateTime do
   use Timex
 
   def to_ics(%DateTime{} = timestamp) do
     format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}Z"
+
     {:ok, result} =
       timestamp
       |> Timex.Timezone.convert("UTC")

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -18,7 +18,10 @@ defimpl Value, for: DateTime do
 
   def to_ics(%DateTime{} = timestamp) do
     format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}Z"
-    {:ok, result} = timestamp |> Timex.format(format_string)
+    {:ok, result} =
+      timestamp
+      |> Timex.Timezone.convert("UTC")
+      |> Timex.format(format_string)
     result
   end
 end

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -48,7 +48,8 @@ defimpl Value, for: Tuple do
   end
 
   def to_ics(timestamp) when is_datetime_tuple(timestamp) do
-    Timex.to_datetime(timestamp)
+    timestamp
+    |> Timex.to_datetime
     |> Value.to_ics
   end
 

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -20,6 +20,10 @@ defimpl Value, for: Tuple do
     end
   end
 
+  @doc """
+  This macro is used to establish whether a tuple is in the Erlang Timestamp
+  format (`{{year, month, day}, {hour, minute, second}}`).
+  """
   defmacro is_datetime_tuple(x) do
     quote do
       # Year
@@ -47,6 +51,9 @@ defimpl Value, for: Tuple do
     end
   end
 
+  @doc """
+  This function converts Erlang timestamp tuples into DateTimes.
+  """
   def to_ics(timestamp) when is_datetime_tuple(timestamp) do
     timestamp
     |> Timex.to_datetime
@@ -60,6 +67,10 @@ end
 defimpl Value, for: DateTime do
   use Timex
 
+  @doc """
+  This function converts DateTimes to UTC timezone and then into Strings in the
+  iCal format
+  """
   def to_ics(%DateTime{} = timestamp) do
     format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}Z"
 

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -5,7 +5,6 @@ end
 
 alias ICalendar.Value
 
-
 defimpl Value, for: BitString do
   def to_ics(x) do
     x
@@ -14,55 +13,15 @@ defimpl Value, for: BitString do
   end
 end
 
-defimpl Value, for: Tuple do
-  defmacro elem2(x, i1, i2) do
-    quote do
-      unquote(x) |> elem(unquote(i1)) |> elem(unquote(i2))
-    end
+defimpl Value, for: DateTime do
+  use Timex
+
+  def to_ics(%DateTime{} = timestamp) do
+    format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}Z"
+    {:ok, result} = timestamp |> Timex.format(format_string)
+    result
   end
-
-  defmacro is_datetime_tuple(x) do
-    quote do
-      # Year
-      ( unquote(x) |> elem2(0, 0)  |> is_integer) and
-      # Month
-      ( unquote(x) |> elem2(0, 1)  |> is_integer) and
-      ((unquote(x) |> elem2(0, 1)) <= 12) and
-      ((unquote(x) |> elem2(0, 1)) >= 1) and
-      # Day
-      ( unquote(x) |> elem2(0, 2)  |> is_integer) and
-      ((unquote(x) |> elem2(0, 2)) <= 31) and
-      ((unquote(x) |> elem2(0, 2)) >= 1) and
-      # Hour
-      ( unquote(x) |> elem2(1, 0)  |> is_integer) and
-      ((unquote(x) |> elem2(1, 0)) <= 23) and
-      ((unquote(x) |> elem2(1, 0)) >= 0) and
-      # Minute
-      ( unquote(x) |> elem2(1, 1)  |> is_integer) and
-      ((unquote(x) |> elem2(1, 1)) <= 59) and
-      ((unquote(x) |> elem2(1, 1)) >= 0) and
-      # Second
-      ( unquote(x) |> elem2(1, 2)  |> is_integer) and
-      ((unquote(x) |> elem2(1, 2)) <= 60) and
-      ((unquote(x) |> elem2(1, 2)) >= 0)
-    end
-  end
-
-
-  def to_ics({{yy, mm, dd}, {h, m, s}} = x) when is_datetime_tuple(x) do
-    import String, only: [rjust: 3]
-    year  = yy |> to_string |> rjust(4, ?0)
-    month = mm |> to_string |> rjust(2, ?0)
-    day   = dd |> to_string |> rjust(2, ?0)
-    hour  = h  |> to_string |> rjust(2, ?0)
-    min   = m  |> to_string |> rjust(2, ?0)
-    sec   = s  |> to_string |> rjust(2, ?0)
-    year <> month <> day <> "T" <> hour <> min <> sec <> "Z"
-  end
-
-  def to_ics(x), do: x
 end
-
 
 defimpl Value, for: Any do
   def to_ics(x), do: x

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule ICalendar.Mixfile do
   end
 
   def application do
-    [applications: []]
+    [applications: [:timex]]
   end
 
   defp deps do
@@ -38,6 +38,9 @@ defmodule ICalendar.Mixfile do
       {:earmark, ">= 0.0.0", only: [:dev, :test]},
       # Documentation generator
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},
+
+      # For full timezone support
+      {:timex, "~> 3.0.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,16 @@
-%{"dogma": {:hex, :dogma, "0.1.7", "927f76a89a809db96e0983b922fc899f601352690aefa123529b8aa0c45123b2", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}]},
+%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
+  "dogma": {:hex, :dogma, "0.1.7", "927f76a89a809db96e0983b922fc899f601352690aefa123529b8aa0c45123b2", [:mix], [{:poison, ">= 1.0.0", [hex: :poison, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.1", "658dbfc8cc5b0fac192f0f3254efe66ee6294200804a291549e0aeb052053bba", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
+  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []}}
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "timex": {:hex, :timex, "3.0.8", "71d5ebafcdc557c6c866cdc196c5054f587e7cd1118ad8937e2293d51fc85608", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -14,8 +14,8 @@ defmodule ICalendar.DeserializeTest do
     """
     event = ICalendar.from_ics(ics)
     assert event == %Event{
-      dtstart: {{2015, 12, 24}, {8, 30, 00}},
-      dtend: {{2015, 12, 24}, {8, 45, 00}},
+      dtstart: ~N[2015-12-24 08:30:00],
+      dtend: ~N[2015-12-24 08:45:00],
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water."
     }

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -14,8 +14,8 @@ defmodule ICalendar.DeserializeTest do
     """
     event = ICalendar.from_ics(ics)
     assert event == %Event{
-      dtstart: ~N[2015-12-24 08:30:00],
-      dtend: ~N[2015-12-24 08:45:00],
+      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
+      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water."
     }

--- a/test/icalendar/event_test.exs
+++ b/test/icalendar/event_test.exs
@@ -24,10 +24,10 @@ defmodule ICalendar.EventTest do
     """
   end
 
-  test "ICalendar.to_ics/1 with start and end" do
+  test "ICalendar.to_ics/1 with datetime start and end" do
     ics = %Event{
-      dtstart: {{2015, 12, 24}, {8, 30, 00}},
-      dtend:   {{2015, 12, 24}, {8, 45, 00}},
+      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
+      dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
     } |> ICalendar.to_ics
     assert ics == """
     BEGIN:VEVENT

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -20,8 +20,8 @@ defmodule ICalendar.Util.DeserializeTest do
 
     assert event == %Event{
       description: "Escape from the world. Stare at some water.",
-      dtend: {{2015, 12, 24}, {8, 45, 0}},
-      dtstart: {{2015, 12, 24}, {8, 30, 0}},
+      dtstart: ~N[2015-12-24 08:30:00],
+      dtend: ~N[2015-12-24 08:45:00],
       location: nil,
       summary: "Going fishing"
     }

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -20,8 +20,8 @@ defmodule ICalendar.Util.DeserializeTest do
 
     assert event == %Event{
       description: "Escape from the world. Stare at some water.",
-      dtstart: ~N[2015-12-24 08:30:00],
-      dtend: ~N[2015-12-24 08:45:00],
+      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
+      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
       location: nil,
       summary: "Going fishing"
     }

--- a/test/icalendar/value_test.exs
+++ b/test/icalendar/value_test.exs
@@ -13,6 +13,16 @@ defmodule ICalendar.ValueTest do
     assert Value.to_ics(time) == "20160101T090201Z"
   end
 
+  test "value of a datetime tuple" do
+    result = Value.to_ics({{2016, 1, 4}, {0, 42, 23}})
+    assert result == "20160104T004223Z"
+  end
+
+  test "value of a nearly datetime tuple" do
+    result = Value.to_ics({{2016, 13, 4}, {0, 42, 23}})
+    assert result == {{2016, 13, 4}, {0, 42, 23}}
+  end
+
   test "value of a very different tupe" do
     result = Value.to_ics({:ok, "Hi there"})
     assert result == {:ok, "Hi there"}

--- a/test/icalendar/value_test.exs
+++ b/test/icalendar/value_test.exs
@@ -3,14 +3,9 @@ defmodule ICalendar.ValueTest do
 
   alias ICalendar.Value
 
-  test "value of a datetime tuple" do
-    result = Value.to_ics({{2016, 1, 4}, {0, 42, 23}})
+  test "value of a datetime" do
+    result = Value.to_ics(Timex.to_datetime({{2016, 1, 4}, {0, 42, 23}}))
     assert result == "20160104T004223Z"
-  end
-
-  test "value of a nearly datetime tuple" do
-    result = Value.to_ics({{2016, 13, 4}, {0, 42, 23}})
-    assert result == {{2016, 13, 4}, {0, 42, 23}}
   end
 
   test "value of a very different tupe" do

--- a/test/icalendar/value_test.exs
+++ b/test/icalendar/value_test.exs
@@ -8,6 +8,11 @@ defmodule ICalendar.ValueTest do
     assert result == "20160104T004223Z"
   end
 
+  test "datetimes' timezones are all converted to UTC" do
+    time = Timex.to_datetime({{2016, 1, 1}, {3, 2, 1}}, "America/Chicago")
+    assert Value.to_ics(time) == "20160101T090201Z"
+  end
+
   test "value of a very different tupe" do
     result = Value.to_ics({:ok, "Hi there"})
     assert result == {:ok, "Hi there"}

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -47,7 +47,7 @@ defmodule ICalendarTest do
     """
   end
 
-  test "Icalnder.to_ics/1 with location and sanitization" do
+  test "Icalender.to_ics/1 with location and sanitization" do
     events = [
       %ICalendar.Event{
         summary: "Film with Amy and Adam",
@@ -72,4 +72,24 @@ defmodule ICalendarTest do
     END:VCALENDAR
     """
   end
+
+
+  test "ICalender.to_ics/1 -> ICalendar.from_ics/1 and back again" do
+    events = [
+      %ICalendar.Event{
+        summary: "Film with Amy and Adam",
+        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
+        dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+        description: "Let's go see Star Wars, and have fun.",
+        location: "123 Fun Street, Toronto ON, Canada"
+},
+    ]
+    new_event =
+      %ICalendar{ events: events }
+      |> ICalendar.to_ics
+      |> ICalendar.from_ics
+
+    assert events |> List.first == new_event
+  end
+
 end

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -15,14 +15,14 @@ defmodule ICalendarTest do
     events = [
       %ICalendar.Event{
         summary: "Film with Amy and Adam",
-        dtstart: {{2015, 12, 24}, {8, 30, 00}},
-        dtend:   {{2015, 12, 24}, {8, 45, 00}},
+        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
+        dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
         description: "Let's go see Star Wars.",
       },
       %ICalendar.Event{
         summary: "Morning meeting",
-        dtstart: {{2015, 12, 24}, {19, 00, 00}},
-        dtend:   {{2015, 12, 24}, {22, 30, 00}},
+        dtstart: Timex.to_datetime({{2015, 12, 24}, {19, 00, 00}}),
+        dtend:   Timex.to_datetime({{2015, 12, 24}, {22, 30, 00}}),
         description: "A big long meeting with lots of details.",
       },
     ]
@@ -51,8 +51,8 @@ defmodule ICalendarTest do
     events = [
       %ICalendar.Event{
         summary: "Film with Amy and Adam",
-        dtstart: {{2015, 12, 24}, {8, 30, 00}},
-        dtend:   {{2015, 12, 24}, {8, 45, 00}},
+        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
+        dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
         description: "Let's go see Star Wars, and have fun.",
         location: "123 Fun Street, Toronto ON, Canada"
       },


### PR DESCRIPTION
This PR replaces the erl tuple-based syntax for using Timex's `DateTime`s instead. This allows us to support Elixir DateTime's, but to also fully support Timezones. In order to keep things simple to begin with, the change currently formats everything to UTC - so the time is accurate but the original timezone is lost.

Later, the `TZID` attribute can be supported to enable timezone serialization (and deserialization), which would allow us to remove the UTC normalization section of the code.

I'm looking for feedback on this - is it acceptable to drop support for Erlang tuples if we add Timex as a dependency?
