### PR TITLE
[RFC] Timezone Serialization & Deserialization

### DIFF
--- a/lib/icalendar/event.ex
+++ b/lib/icalendar/event.ex
@@ -32,7 +32,7 @@ defimpl ICalendar.Serialize, for: ICalendar.Event do
 
   defp to_kv({key, raw_value}) do
     name  = key |> to_string |> String.upcase
-    value = Value.to_ics( raw_value )
-    KV.build( name, value )
+    value = Value.to_ics(raw_value)
+    KV.build(name, value, raw_value)
   end
 end

--- a/lib/icalendar/event.ex
+++ b/lib/icalendar/event.ex
@@ -12,7 +12,6 @@ end
 
 defimpl ICalendar.Serialize, for: ICalendar.Event do
   alias ICalendar.Util.KV
-  alias ICalendar.Value
 
   def to_ics(event) do
     contents = to_kvs(event)
@@ -30,9 +29,8 @@ defimpl ICalendar.Serialize, for: ICalendar.Event do
     |> Enum.join
   end
 
-  defp to_kv({key, raw_value}) do
+  defp to_kv({key, value}) do
     name  = key |> to_string |> String.upcase
-    value = Value.to_ics(raw_value)
-    KV.build(name, value, raw_value)
+    KV.build(name, value)
   end
 end

--- a/lib/icalendar/property.ex
+++ b/lib/icalendar/property.ex
@@ -1,0 +1,10 @@
+defmodule ICalendar.Property do
+  @moduledoc """
+  Provide structure to define properties of an Event
+  """
+
+  defstruct key: nil,
+            value: nil,
+            params: %{}
+
+end

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -53,26 +53,36 @@ defmodule ICalendar.Util.Deserialize do
     [key, params]
   end
 
-  def parse_attr(%Property{key: "DESCRIPTION", value: description},
-                 acc) do
+  def parse_attr(
+    %Property{key: "DESCRIPTION", value: description},
+    acc
+  ) do
     %{acc | description: desanitized(description)}
   end
-  def parse_attr(%Property{key: "DTSTART", value: dtstart, params: params},
-                 acc) do
+  def parse_attr(
+    %Property{key: "DTSTART", value: dtstart, params: params},
+    acc
+  ) do
     {:ok, timestamp} = to_date(dtstart, params)
     %{acc | dtstart: timestamp}
   end
-  def parse_attr(%Property{key: "DTEND", value: dtend, params: params},
-                 acc) do
+  def parse_attr(
+    %Property{key: "DTEND", value: dtend, params: params},
+    acc
+  ) do
     {:ok, timestamp} = to_date(dtend, params)
     %{acc | dtend: timestamp}
   end
-  def parse_attr(%Property{key: "SUMMARY", value: summary},
-                 acc) do
+  def parse_attr(
+    %Property{key: "SUMMARY", value: summary},
+    acc
+  ) do
     %{acc | summary: desanitized(summary)}
   end
-  def parse_attr(%Property{key: "LOCATION", value: location},
-                 acc) do
+  def parse_attr(
+    %Property{key: "LOCATION", value: location},
+    acc
+  ) do
     %{acc | location: desanitized(location)}
   end
   def parse_attr(_, acc), do: acc

--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -16,7 +16,9 @@ defmodule ICalendar.Util.KV do
 
   DateTime values will add timezones:
 
-    iex> date = Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}, "America/Chicago")
+    iex> date =
+    ...>   {{2015, 12, 24}, {8, 30, 0}}
+    ...>   |> Timex.to_datetime("America/Chicago")
     ...> ICalendar.Util.KV.build("foo", "20151224T083000", date)
     "foo;TZID=America/Chicago:20151224T083000\n"
   """

--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -3,15 +3,17 @@ defmodule ICalendar.Util.KV do
   Build ICalendar key-value strings
   """
 
+  alias ICalendar.Value
+
   @doc ~S"""
   Convert a key and value to an iCal line:
 
-    iex> ICalendar.Util.KV.build("foo", "bar", "bar")
+    iex> ICalendar.Util.KV.build("foo", "bar")
     "foo:bar\n"
 
   Don't add empty values:
 
-    iex> ICalendar.Util.KV.build("foo", nil, nil)
+    iex> ICalendar.Util.KV.build("foo", nil)
     ""
 
   DateTime values will add timezones:
@@ -19,27 +21,27 @@ defmodule ICalendar.Util.KV do
     iex> date =
     ...>   {{2015, 12, 24}, {8, 30, 0}}
     ...>   |> Timex.to_datetime("America/Chicago")
-    ...> ICalendar.Util.KV.build("foo", "20151224T083000", date)
+    ...> ICalendar.Util.KV.build("foo", date)
     "foo;TZID=America/Chicago:20151224T083000\n"
   """
-  def build(_, nil, _) do
+  def build(_, nil) do
     ""
   end
 
-  def build("LOCATION" = key, value, _raw) do
-    build_sanitized(key, value)
+  def build("LOCATION" = key, value) do
+    build_sanitized(key, Value.to_ics(value))
   end
 
-  def build("DESCRIPTION" = key, value, _raw) do
-    build_sanitized(key, value)
+  def build("DESCRIPTION" = key, value) do
+    build_sanitized(key, Value.to_ics(value))
   end
 
-  def build(key, value, date = %DateTime{}) do
-    "#{key};TZID=#{date.time_zone}:#{value}\n"
+  def build(key, date = %DateTime{}) do
+    "#{key};TZID=#{date.time_zone}:#{Value.to_ics(date)}\n"
   end
 
-  def build(key, value, _raw) do
-    "#{key}:#{value}\n"
+  def build(key, value) do
+    "#{key}:#{Value.to_ics(value)}\n"
   end
 
   defp build_sanitized(key, value) do

--- a/lib/icalendar/value.ex
+++ b/lib/icalendar/value.ex
@@ -72,11 +72,10 @@ defimpl Value, for: DateTime do
   iCal format
   """
   def to_ics(%DateTime{} = timestamp) do
-    format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}Z"
+    format_string = "{YYYY}{0M}{0D}T{h24}{m}{s}"
 
     {:ok, result} =
       timestamp
-      |> Timex.Timezone.convert("UTC")
       |> Timex.format(format_string)
     result
   end

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -3,21 +3,39 @@ defmodule ICalendar.DeserializeTest do
 
   alias ICalendar.Event
 
-  test "ICalendar.from_ics/1" do
-    ics = """
-    BEGIN:VEVENT
-    DESCRIPTION:Escape from the world. Stare at some water.
-    SUMMARY:Going fishing
-    DTEND:20151224T084500Z
-    DTSTART:20151224T083000Z
-    END:VEVENT
-    """
-    event = ICalendar.from_ics(ics)
-    assert event == %Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
-      summary: "Going fishing",
-      description: "Escape from the world. Stare at some water."
-    }
+  describe "ICalendar.from_ics/1" do
+
+    test "Single Event" do
+      ics = """
+      BEGIN:VEVENT
+      DESCRIPTION:Escape from the world. Stare at some water.
+      SUMMARY:Going fishing
+      DTEND:20151224T084500Z
+      DTSTART:20151224T083000Z
+      END:VEVENT
+      """
+      event = ICalendar.from_ics(ics)
+      assert event == %Event{
+        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
+        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
+        summary: "Going fishing",
+        description: "Escape from the world. Stare at some water."
+      }
+    end
+
+    test "with Timezone" do
+      ics = """
+      BEGIN:VEVENT
+      DTEND;TZID=America/Chicago:22221224T084500
+      DTSTART;TZID=America/Chicago:22221224T083000
+      END:VEVENT
+      """
+
+      event = ICalendar.from_ics(ics)
+      assert event.dtstart.time_zone == "America/Chicago"
+      assert event.dtend.time_zone == "America/Chicago"
+    end
+
   end
+
 end

--- a/test/icalendar/event_test.exs
+++ b/test/icalendar/event_test.exs
@@ -38,10 +38,17 @@ defmodule ICalendar.EventTest do
   end
 
   test "ICalendar.to_ics/1 with datetime with timezone" do
-    ics = %Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}, "America/Chicago"),
-      dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}, "America/Chicago"),
-    } |> ICalendar.to_ics
+    dtstart =
+      {{2015, 12, 24}, {8, 30, 00}}
+      |> Timex.to_datetime("America/Chicago")
+
+    dtend =
+      {{2015, 12, 24}, {8, 45, 00}}
+      |> Timex.to_datetime("America/Chicago")
+
+    ics =
+      %Event{dtstart: dtstart, dtend: dtend}
+      |> ICalendar.to_ics
 
     assert ics == """
     BEGIN:VEVENT

--- a/test/icalendar/event_test.exs
+++ b/test/icalendar/event_test.exs
@@ -31,9 +31,24 @@ defmodule ICalendar.EventTest do
     } |> ICalendar.to_ics
     assert ics == """
     BEGIN:VEVENT
-    DTEND:20151224T084500Z
-    DTSTART:20151224T083000Z
+    DTEND;TZID=Etc/UTC:20151224T084500
+    DTSTART;TZID=Etc/UTC:20151224T083000
     END:VEVENT
     """
+  end
+
+  test "ICalendar.to_ics/1 with datetime with timezone" do
+    ics = %Event{
+      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}, "America/Chicago"),
+      dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}, "America/Chicago"),
+    } |> ICalendar.to_ics
+
+    assert ics == """
+    BEGIN:VEVENT
+    DTEND;TZID=America/Chicago:20151224T084500
+    DTSTART;TZID=America/Chicago:20151224T083000
+    END:VEVENT
+    """
+
   end
 end

--- a/test/icalendar/value_test.exs
+++ b/test/icalendar/value_test.exs
@@ -5,17 +5,12 @@ defmodule ICalendar.ValueTest do
 
   test "value of a datetime" do
     result = Value.to_ics(Timex.to_datetime({{2016, 1, 4}, {0, 42, 23}}))
-    assert result == "20160104T004223Z"
-  end
-
-  test "datetimes' timezones are all converted to UTC" do
-    time = Timex.to_datetime({{2016, 1, 1}, {3, 2, 1}}, "America/Chicago")
-    assert Value.to_ics(time) == "20160101T090201Z"
+    assert result == "20160104T004223"
   end
 
   test "value of a datetime tuple" do
     result = Value.to_ics({{2016, 1, 4}, {0, 42, 23}})
-    assert result == "20160104T004223Z"
+    assert result == "20160104T004223"
   end
 
   test "value of a nearly datetime tuple" do
@@ -27,7 +22,6 @@ defmodule ICalendar.ValueTest do
     result = Value.to_ics({:ok, "Hi there"})
     assert result == {:ok, "Hi there"}
   end
-
 
   test "value of a string with newline" do
     result = Value.to_ics """

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -27,20 +27,21 @@ defmodule ICalendarTest do
       },
     ]
     ics = %ICalendar{ events: events } |> ICalendar.to_ics
+
     assert ics == """
     BEGIN:VCALENDAR
     CALSCALE:GREGORIAN
     VERSION:2.0
     BEGIN:VEVENT
     DESCRIPTION:Let's go see Star Wars.
-    DTEND:20151224T084500Z
-    DTSTART:20151224T083000Z
+    DTEND;TZID=Etc/UTC:20151224T084500
+    DTSTART;TZID=Etc/UTC:20151224T083000
     SUMMARY:Film with Amy and Adam
     END:VEVENT
     BEGIN:VEVENT
     DESCRIPTION:A big long meeting with lots of details.
-    DTEND:20151224T223000Z
-    DTSTART:20151224T190000Z
+    DTEND;TZID=Etc/UTC:20151224T223000
+    DTSTART;TZID=Etc/UTC:20151224T190000
     SUMMARY:Morning meeting
     END:VEVENT
     END:VCALENDAR
@@ -64,8 +65,8 @@ defmodule ICalendarTest do
     VERSION:2.0
     BEGIN:VEVENT
     DESCRIPTION:Let's go see Star Wars\\, and have fun.
-    DTEND:20151224T084500Z
-    DTSTART:20151224T083000Z
+    DTEND;TZID=Etc/UTC:20151224T084500
+    DTSTART;TZID=Etc/UTC:20151224T083000
     LOCATION:123 Fun Street\\, Toronto ON\\, Canada
     SUMMARY:Film with Amy and Adam
     END:VEVENT
@@ -82,7 +83,7 @@ defmodule ICalendarTest do
         dtend:   Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
         description: "Let's go see Star Wars, and have fun.",
         location: "123 Fun Street, Toronto ON, Canada"
-},
+      }
     ]
     new_event =
       %ICalendar{ events: events }


### PR DESCRIPTION
This PR will add the ability for icalendar to take timezones into consideration when serializing and deserializing into and from ics.
- [x] Deserializing ics strings into icalendar retains the `TZID` value in dates.
- [x] Serializing icalendar events into ics adds `TZID` to the output dates
