### PR TITLE
Add support for CR+LF line endings

### DIFF
--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -11,6 +11,7 @@ defimpl ICalendar.Deserialize, for: BitString do
     ics
     |> String.trim
     |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
     |> Deserialize.build_event
   end
 end

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -36,6 +36,15 @@ defmodule ICalendar.DeserializeTest do
       assert event.dtend.time_zone == "America/Chicago"
     end
 
-  end
+    test "with CR+LF line endings" do
+      ics = """
+      DESCRIPTION:CR+LF line endings\r\nSUMMARY:Going fishing\r
+      DTEND:20151224T084500Z\r\nDTSTART:20151224T083000Z\r
+      END:VEVENT
+      """
 
+      event = ICalendar.from_ics(ics)
+      assert event.description == "CR+LF line endings"
+    end
+  end
 end


### PR DESCRIPTION
Currently the library cannot parse ical files using CR+LF endings. It fails with this error:

```
** (MatchError) no match of right hand side value: {:error, "Expected `timezone name` at line 1, column 17."}
         lib/icalendar/util/deserialize.ex:66: ICalendar.Util.Deserialize.parse_attr/2
(elixir) lib/enum.ex:1623: Enum."-reduce/3-lists^foldl/2-0-"/3
```

I'm not even sure that the ical spec supports this, but Calendar.app seems to handle them fine. I encountered this issue when parsing feeds from http://motocal.net.

Feel free to close if you think this is not something the library should handle.
