### PR TITLE
use parentheses to remove ambiguity in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule ICalendar.Mixfile do
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
 
       name: "ICalendar",
       source_url: "https://github.com/lpil/icalendar",


### PR DESCRIPTION
Got this warning

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/icalendar/mix.exs:13
```