### PR TITLE
Loosen Timex dependency requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule ICalendar.Mixfile do
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},
 
       # For full timezone support
-      {:timex, "~> 3.0.0"}
+      {:timex, "~> 3.0"}
     ]
   end
 end


### PR DESCRIPTION
Timex has updated to 3.1.13. I loosened the requirement to allow 3.x and all seems to be working well in the app where I'm using iCalendar.