### PR TITLE
Add functions to use the lib for a Phoenix ics endpoint

### DIFF
--- a/lib/icalendar.ex
+++ b/lib/icalendar.ex
@@ -6,6 +6,34 @@ defmodule ICalendar do
   defstruct events: []
   defdelegate to_ics(events), to: ICalendar.Serialize
   defdelegate from_ics(events), to: ICalendar.Deserialize
+
+  @doc """
+  To create a Phoenix/Plug controller and view that output ics format:
+  Add to your config.exs:
+  ```
+  config :phoenix, :format_encoders,
+    ics: ICalendar
+  ```
+  In your controller use:
+  `
+    calendar = %ICalendar{ events: events }
+    render(conn, "index.ics", calendar: calendar)
+  `
+  The important part here is `.ics`. This triggers the `format_encoder`.
+
+  In your view can put:
+  ```
+  def render("index.ics", %{calendar: calendar}) do
+    calendar
+  end
+  ```
+  """
+  def encode_to_iodata(calendar, options \\ []) do
+    {:ok, encode_to_iodata!(calendar, options)}
+  end
+  def encode_to_iodata!(calendar, _options \\ []) do
+    to_ics(calendar)
+  end
 end
 
 defimpl ICalendar.Serialize, for: ICalendar do


### PR DESCRIPTION
It's just a few lines of code, and some documentation.
With this, it should be very easy to create an endpoint that can be used as an ics feed.
#22 