### PR TITLE
Add PRODID support

### DIFF
--- a/lib/icalendar.ex
+++ b/lib/icalendar.ex
@@ -4,7 +4,7 @@ defmodule ICalendar do
   """
 
   defstruct events: []
-  defdelegate to_ics(events), to: ICalendar.Serialize
+  defdelegate to_ics(events, options \\ []), to: ICalendar.Serialize
   defdelegate from_ics(events), to: ICalendar.Deserialize
 
   @doc """
@@ -38,13 +38,15 @@ defmodule ICalendar do
 end
 
 defimpl ICalendar.Serialize, for: ICalendar do
-  def to_ics(calendar) do
+  def to_ics(calendar, options \\ []) do
     events = Enum.map(calendar.events, &ICalendar.Serialize.to_ics/1)
+    vendor = Keyword.get(options, :vendor, "Elixir ICalendar")
 
     """
     BEGIN:VCALENDAR
     CALSCALE:GREGORIAN
     VERSION:2.0
+    PRODID:-//Elixir ICalendar//#{vendor}//EN
     #{events}END:VCALENDAR
     """
   end

--- a/lib/icalendar/event.ex
+++ b/lib/icalendar/event.ex
@@ -10,6 +10,7 @@ defmodule ICalendar.Event do
             location: nil,
             url: nil,
             uid: nil,
+            prodid: nil,
             status: nil,
             categories: nil,
             class: nil,
@@ -20,7 +21,7 @@ end
 defimpl ICalendar.Serialize, for: ICalendar.Event do
   alias ICalendar.Util.KV
 
-  def to_ics(event) do
+  def to_ics(event, _options \\ []) do
     contents = to_kvs(event)
 
     """

--- a/lib/icalendar/serialize.ex
+++ b/lib/icalendar/serialize.ex
@@ -1,11 +1,17 @@
 defprotocol ICalendar.Serialize do
-  def to_ics(data)
+  @doc """
+  Serialize data to iCalendar format.
+
+  Supported options for serializing a calendar:
+  * `vendor` a string containing the vendor's name. Will produce `PRODID:-//ICalendar//My Name//EN`.
+  """
+  def to_ics(data, options \\ [])
 end
 
 alias ICalendar.Serialize
 
 defimpl Serialize, for: List do
-  def to_ics(collection) do
+  def to_ics(collection, _options \\ []) do
     collection
     |> Enum.map(&Serialize.to_ics/1)
     |> Enum.join("\n")

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -1,6 +1,8 @@
 defmodule ICalendarTest do
   use ExUnit.Case
 
+  @vendor "ICalendar Test"
+
   test "ICalendar.to_ics/1 of empty calendar" do
     ics = %ICalendar{} |> ICalendar.to_ics()
 
@@ -8,6 +10,19 @@ defmodule ICalendarTest do
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
+           END:VCALENDAR
+           """
+  end
+
+  test "ICalendar.to_ics/1 of empty calendar with custom vendor" do
+    ics = %ICalendar{} |> ICalendar.to_ics(vendor: @vendor)
+
+    assert ics == """
+           BEGIN:VCALENDAR
+           CALSCALE:GREGORIAN
+           VERSION:2.0
+           PRODID:-//Elixir ICalendar//#{@vendor}//EN
            END:VCALENDAR
            """
   end
@@ -34,6 +49,7 @@ defmodule ICalendarTest do
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
            DTEND;TZID=Etc/UTC:20151224T084500
@@ -67,6 +83,7 @@ defmodule ICalendarTest do
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars\\, and have fun.
            DTEND;TZID=Etc/UTC:20151224T084500
@@ -91,7 +108,7 @@ defmodule ICalendarTest do
 
     new_event =
       %ICalendar{events: events}
-      |> ICalendar.to_ics()
+      |> ICalendar.to_ics(vendor: @vendor)
       |> ICalendar.from_ics()
 
     assert events |> List.first() == new_event
@@ -121,6 +138,7 @@ defmodule ICalendarTest do
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
            DTEND;TZID=Etc/UTC:20151224T084500
@@ -161,6 +179,7 @@ defmodule ICalendarTest do
            BEGIN:VCALENDAR
            CALSCALE:GREGORIAN
            VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
            DTEND;TZID=Etc/UTC:20151224T084500


### PR DESCRIPTION
Adds an option param to `to_ics/2` so that we can customize the vendor string.