### PR TITLE
Dates shouldn't have TZID when UTC

### DIFF
--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -52,6 +52,10 @@ defmodule ICalendar.Util.KV do
     "#{key}:#{lat};#{lon}\n"
   end
 
+  def build(key, date = %DateTime{time_zone: "Etc/UTC"}) do
+    "#{key}:#{Value.to_ics(date)}\n"
+  end
+
   def build(key, date = %DateTime{}) do
     "#{key};TZID=#{date.time_zone}:#{Value.to_ics(date)}\n"
   end

--- a/test/icalendar/event_test.exs
+++ b/test/icalendar/event_test.exs
@@ -56,8 +56,8 @@ defmodule ICalendar.EventTest do
 
     assert ics == """
            BEGIN:VEVENT
-           DTEND;TZID=Etc/UTC:20151224T084500
-           DTSTART;TZID=Etc/UTC:20151224T083000
+           DTEND:20151224T084500
+           DTSTART:20151224T083000
            END:VEVENT
            """
   end

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -36,14 +36,14 @@ defmodule ICalendarTest do
            VERSION:2.0
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
-           DTEND;TZID=Etc/UTC:20151224T084500
-           DTSTART;TZID=Etc/UTC:20151224T083000
+           DTEND:20151224T084500
+           DTSTART:20151224T083000
            SUMMARY:Film with Amy and Adam
            END:VEVENT
            BEGIN:VEVENT
            DESCRIPTION:A big long meeting with lots of details.
-           DTEND;TZID=Etc/UTC:20151224T223000
-           DTSTART;TZID=Etc/UTC:20151224T190000
+           DTEND:20151224T223000
+           DTSTART:20151224T190000
            SUMMARY:Morning meeting
            END:VEVENT
            END:VCALENDAR
@@ -69,8 +69,8 @@ defmodule ICalendarTest do
            VERSION:2.0
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars\\, and have fun.
-           DTEND;TZID=Etc/UTC:20151224T084500
-           DTSTART;TZID=Etc/UTC:20151224T083000
+           DTEND:20151224T084500
+           DTSTART:20151224T083000
            LOCATION:123 Fun Street\\, Toronto ON\\, Canada
            SUMMARY:Film with Amy and Adam
            END:VEVENT
@@ -123,14 +123,14 @@ defmodule ICalendarTest do
            VERSION:2.0
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
-           DTEND;TZID=Etc/UTC:20151224T084500
-           DTSTART;TZID=Etc/UTC:20151224T083000
+           DTEND:20151224T084500
+           DTSTART:20151224T083000
            SUMMARY:Film with Amy and Adam
            END:VEVENT
            BEGIN:VEVENT
            DESCRIPTION:A big long meeting with lots of details.
-           DTEND;TZID=Etc/UTC:20151224T223000
-           DTSTART;TZID=Etc/UTC:20151224T190000
+           DTEND:20151224T223000
+           DTSTART:20151224T190000
            SUMMARY:Morning meeting
            END:VEVENT
            END:VCALENDAR
@@ -163,14 +163,14 @@ defmodule ICalendarTest do
            VERSION:2.0
            BEGIN:VEVENT
            DESCRIPTION:Let's go see Star Wars.
-           DTEND;TZID=Etc/UTC:20151224T084500
-           DTSTART;TZID=Etc/UTC:20151224T083000
+           DTEND:20151224T084500
+           DTSTART:20151224T083000
            SUMMARY:Film with Amy and Adam
            END:VEVENT
            BEGIN:VEVENT
            DESCRIPTION:A big long meeting with lots of details.
-           DTEND;TZID=Etc/UTC:20151224T223000
-           DTSTART;TZID=Etc/UTC:20151224T190000
+           DTEND:20151224T223000
+           DTSTART:20151224T190000
            SUMMARY:Morning meeting
            END:VEVENT
            END:VCALENDAR


### PR DESCRIPTION
> The "TZID" property parameter MUST NOT be applied to DATE properties and DATE-TIME or TIME properties whose time values are specified in UTC.

https://icalendar.org/iCalendar-RFC-5545/3-2-19-time-zone-identifier.html

Will need rebase on #30