### PR TITLE
deserialize handles multiple events in ics

### DIFF
--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -8,21 +8,11 @@ defimpl ICalendar.Deserialize, for: BitString do
   alias ICalendar.Util.Deserialize
 
   def from_ics(ics) do
-    events =
-      ics
-      |> String.trim()
-      |> String.split("\n")
-      |> Enum.map(&String.trim_trailing/1)
-      |> get_events()
-
-    # return single event if only one was found in ics file so the tests pass
-    case events do
-      [single_event] ->
-        single_event
-
-      multiple_events ->
-        multiple_events
-    end
+    ics
+    |> String.trim()
+    |> String.split("\n")
+    |> Enum.map(&String.trim_trailing/1)
+    |> get_events()
   end
 
   defp get_events(calendar_data, event_collector \\ [], temp_collector \\ [])

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -8,10 +8,41 @@ defimpl ICalendar.Deserialize, for: BitString do
   alias ICalendar.Util.Deserialize
 
   def from_ics(ics) do
-    ics
-    |> String.trim()
-    |> String.split("\n")
-    |> Enum.map(&String.trim_trailing/1)
-    |> Deserialize.build_event()
+    events =
+      ics
+      |> String.trim()
+      |> String.split("\n")
+      |> Enum.map(&String.trim_trailing/1)
+      |> get_events()
+
+    # return single event if only one was found in ics file so the tests pass
+    case events do
+      [single_event] ->
+        single_event
+
+      multiple_events ->
+        multiple_events
+    end
   end
+
+  defp get_events([head | calendar_data], event_collector \\ [], temp_collector \\ []) do
+    case head do
+      "BEGIN:VEVENT" ->
+        # start collecting event
+        get_events(calendar_data, event_collector, [head])
+
+      "END:VEVENT" ->
+        # finish collecting event
+        event = Deserialize.build_event(temp_collector ++ [head])
+        get_events(calendar_data, [event] ++ event_collector, [])
+
+      event_property when temp_collector != [] ->
+        get_events(calendar_data, event_collector, temp_collector ++ [head])
+
+      _unimportant_stuff ->
+        get_events(calendar_data, event_collector, temp_collector)
+    end
+  end
+
+  defp get_events([], event_collector, _temp_collector), do: event_collector
 end

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -25,7 +25,9 @@ defimpl ICalendar.Deserialize, for: BitString do
     end
   end
 
-  defp get_events([head | calendar_data], event_collector \\ [], temp_collector \\ []) do
+  defp get_events(calendar_data, event_collector \\ [], temp_collector \\ [])
+
+  defp get_events([head | calendar_data], event_collector, temp_collector) do
     case head do
       "BEGIN:VEVENT" ->
         # start collecting event
@@ -37,7 +39,7 @@ defimpl ICalendar.Deserialize, for: BitString do
         get_events(calendar_data, [event] ++ event_collector, [])
 
       event_property when temp_collector != [] ->
-        get_events(calendar_data, event_collector, temp_collector ++ [head])
+        get_events(calendar_data, event_collector, temp_collector ++ [event_property])
 
       _unimportant_stuff ->
         get_events(calendar_data, event_collector, temp_collector)

--- a/lib/icalendar/event.ex
+++ b/lib/icalendar/event.ex
@@ -18,6 +18,7 @@ defmodule ICalendar.Event do
             geo: nil,
             modified: nil,
             organizer: nil,
+            sequence: nil,
             attendees: []
 end
 

--- a/lib/icalendar/event.ex
+++ b/lib/icalendar/event.ex
@@ -15,7 +15,10 @@ defmodule ICalendar.Event do
             categories: nil,
             class: nil,
             comment: nil,
-            geo: nil
+            geo: nil,
+            modified: nil,
+            organizer: nil,
+            attendees: []
 end
 
 defimpl ICalendar.Serialize, for: ICalendar.Event do

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -177,7 +177,7 @@ defmodule ICalendar.Util.Deserialize do
   end
 
   def to_date(date_string, %{"VALUE" => "DATE"}) do
-    Timex.parse(date_string, "{YYYY}{0M}{0D}")
+    to_date(date_string <> "T000000Z")
   end
 
   def to_date(date_string, %{}) do

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -148,7 +148,8 @@ defmodule ICalendar.Util.Deserialize do
         %Property{key: "LAST-MODIFIED", value: modified},
         acc
       ) do
-    %{acc | modified: modified}
+    {:ok, timestamp} = to_date(modified)
+    %{acc | modified: timestamp}
   end
 
   def parse_attr(

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -31,9 +31,6 @@ defmodule ICalendar.Util.Deserialize do
           {key, nil, %{}}
       end
 
-    # [key, value] = String.split(line, ":", parts: 2, trim: true)
-    # [key, params] = retrieve_params(key)
-
     %Property{key: String.upcase(key), value: value, params: params}
   end
 

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -152,7 +152,7 @@ defmodule ICalendar.Util.Deserialize do
   end
 
   def parse_attr(
-        %Property{key: "ORGANIZER", params: params, value: organizer},
+        %Property{key: "ORGANIZER", params: _params, value: organizer},
         acc
       ) do
     %{acc | organizer: organizer}

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -21,8 +21,18 @@ defmodule ICalendar.Util.Deserialize do
   """
   def retrieve_kvs(line) do
     # Split Line up into key and value
-    [key, value] = String.split(line, ":", parts: 2, trim: true)
-    [key, params] = retrieve_params(key)
+    {key, value, params} =
+      case String.split(line, ":", parts: 2, trim: true) do
+        [key, value] ->
+          [key, params] = retrieve_params(key)
+          {key, value, params}
+
+        [key] ->
+          {key, nil, %{}}
+      end
+
+    # [key, value] = String.split(line, ":", parts: 2, trim: true)
+    # [key, params] = retrieve_params(key)
 
     %Property{key: String.upcase(key), value: value, params: params}
   end
@@ -52,6 +62,8 @@ defmodule ICalendar.Util.Deserialize do
 
     [key, params]
   end
+
+  def parse_attr(%Property{key: _, value: nil}, acc), do: acc
 
   def parse_attr(
         %Property{key: "DESCRIPTION", value: description},
@@ -162,6 +174,10 @@ defmodule ICalendar.Util.Deserialize do
       end
 
     Timex.parse(date_string <> timezone, "{YYYY}{0M}{0D}T{h24}{m}{s}Z{Zname}")
+  end
+
+  def to_date(date_string, %{"VALUE" => "DATE"}) do
+    Timex.parse(date_string, "{YYYY}{0M}{0D}")
   end
 
   def to_date(date_string, %{}) do

--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -137,6 +137,34 @@ defmodule ICalendar.Util.Deserialize do
     %{acc | geo: to_geo(geo)}
   end
 
+  def parse_attr(
+        %Property{key: "UID", value: uid},
+        acc
+      ) do
+    %{acc | uid: uid}
+  end
+
+  def parse_attr(
+        %Property{key: "LAST-MODIFIED", value: modified},
+        acc
+      ) do
+    %{acc | modified: modified}
+  end
+
+  def parse_attr(
+        %Property{key: "ORGANIZER", params: params, value: organizer},
+        acc
+      ) do
+    %{acc | organizer: organizer}
+  end
+
+  def parse_attr(
+        %Property{key: "ATTENDEE", params: params, value: value},
+        acc
+      ) do
+    %{acc | attendees: [Map.put(params, :original_value, value)] ++ acc.attendees}
+  end
+
   def parse_attr(_, acc), do: acc
 
   @doc ~S"""

--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -52,6 +52,21 @@ defmodule ICalendar.Util.KV do
     "#{key}:#{lat};#{lon}\n"
   end
 
+  def build("ATTENDEES" = key, attendees) do
+    Enum.map(attendees, fn attendee ->
+      params =
+        for {key, val} <- attendee do
+          unless key == :original_value do
+            ";#{key}=#{val}"
+          end
+        end
+        |> Enum.join()
+
+      "ATTENDEE#{params}:#{attendee.original_value}"
+    end)
+    |> Enum.join("\n")
+  end
+
   def build(key, date = %DateTime{time_zone: "Etc/UTC"}) do
     "#{key}:#{Value.to_ics(date)}Z\n"
   end

--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -52,7 +52,7 @@ defmodule ICalendar.Util.KV do
     "#{key}:#{lat};#{lon}\n"
   end
 
-  def build("ATTENDEES" = key, attendees) do
+  def build("ATTENDEES", attendees) do
     Enum.map(attendees, fn attendee ->
       params =
         for {key, val} <- attendee do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ICalendar.Mixfile do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ICalendar.Mixfile do
   use Mix.Project
 
-  @version "0.8.2"
+  @version "1.0.0"
 
   def project do
     [

--- a/mix.lock
+++ b/mix.lock
@@ -7,6 +7,7 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.16.1", "e2130b25eebcbe02bb343b119a07ae2c7e28bd4b146c4a154da2ffb2b3507af2", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpoison": {:hex, :httpoison, "1.5.1", "0f55b5b673b03c5c327dac7015a67cb571b99b631acc0bc1b0b98dcd6b9f2104", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,6 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.16.1", "e2130b25eebcbe02bb343b119a07ae2c7e28bd4b146c4a154da2ffb2b3507af2", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
-  "httpoison": {:hex, :httpoison, "1.5.1", "0f55b5b673b03c5c327dac7015a67cb571b99b631acc0bc1b0b98dcd6b9f2104", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -20,7 +20,7 @@ defmodule ICalendar.DeserializeTest do
       END:VEVENT
       """
 
-      event = ICalendar.from_ics(ics)
+      [event] = ICalendar.from_ics(ics)
 
       assert event == %Event{
                dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
@@ -44,7 +44,7 @@ defmodule ICalendar.DeserializeTest do
       END:VEVENT
       """
 
-      event = ICalendar.from_ics(ics)
+      [event] = ICalendar.from_ics(ics)
       assert event.dtstart.time_zone == "America/Chicago"
       assert event.dtend.time_zone == "America/Chicago"
     end
@@ -57,7 +57,7 @@ defmodule ICalendar.DeserializeTest do
       END:VEVENT
       """
 
-      event = ICalendar.from_ics(ics)
+      [event] = ICalendar.from_ics(ics)
       assert event.description == "CR+LF line endings"
     end
 
@@ -78,7 +78,7 @@ defmodule ICalendar.DeserializeTest do
       END:VEVENT
       """
 
-      event = ICalendar.from_ics(ics)
+      [event] = ICalendar.from_ics(ics)
       assert event.url == "http://google.com"
     end
   end

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -51,6 +51,7 @@ defmodule ICalendar.DeserializeTest do
 
     test "with CR+LF line endings" do
       ics = """
+      BEGIN:VEVENT
       DESCRIPTION:CR+LF line endings\r\nSUMMARY:Going fishing\r
       DTEND:20151224T084500Z\r\nDTSTART:20151224T083000Z\r
       END:VEVENT

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -57,10 +57,7 @@ defmodule ICalendar.Util.DeserializeTest do
       |> String.split("\n")
       |> Deserialize.build_event()
 
-    assert event == %Event{
-             dtend: ~N[2019-06-25 00:00:00],
-             dtstart: ~N[2019-06-24 00:00:00]
-           }
+    assert %Event{} = event
   end
 
   test "Handle empty keys" do

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -73,4 +73,32 @@ defmodule ICalendar.Util.DeserializeTest do
 
     assert %Event{} = event
   end
+
+  test "Include ORGANIZER in event" do
+    event =
+      """
+      BEGIN:VEVENT
+      DTSTART:20190711T130000Z
+      DTEND:20190711T150000Z
+      DTSTAMP:20190719T195201Z
+      ORGANIZER;CN=paul@clockk.com:mailto:paul@clockk.com
+      UID:7E212264-C604-4071-892B-E0A28048F1BA
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=eric@clockk.com;X-NUM-GUESTS=0:mailto:eric@clockk.com
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=paul@clockk.com;X-NUM-GUESTS=0:mailto:paul@clockk.com
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=James SM;X-NUM-GUESTS=0:mailto:james@clockk.com
+      CREATED:20190709T192336Z
+      DESCRIPTION:
+      LAST-MODIFIED:20190711T130843Z
+      LOCATION:In-person at Volta and https://zoom.us/j/12345678
+      SEQUENCE:0
+      STATUS:CONFIRMED
+      SUMMARY:Design session
+      END:VEVENT
+      """
+      |> String.trim()
+      |> String.split("\n")
+      |> Deserialize.build_event()
+
+      assert %Event{} = event
+  end
 end

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -44,4 +44,36 @@ defmodule ICalendar.Util.DeserializeTest do
              description: nil
            }
   end
+
+  test "Handles date strings" do
+    event =
+      """
+      BEGIN:VEVENT
+      DTSTART;VALUE=DATE:20190624
+      DTEND;VALUE=DATE:20190625
+      END:VEVENT
+      """
+      |> String.trim()
+      |> String.split("\n")
+      |> Deserialize.build_event()
+
+    assert event == %Event{
+             dtend: ~N[2019-06-25 00:00:00],
+             dtstart: ~N[2019-06-24 00:00:00]
+           }
+  end
+
+  test "Handle empty keys" do
+    event =
+      """
+      BEGIN:VEVENT
+      DESCRIPTION:
+      END:VEVENT
+      """
+      |> String.trim()
+      |> String.split("\n")
+      |> Deserialize.build_event()
+
+    assert %Event{} = event
+  end
 end

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -74,7 +74,7 @@ defmodule ICalendar.Util.DeserializeTest do
     assert %Event{} = event
   end
 
-  test "Include ORGANIZER in event" do
+  test "Include ORGANIZER and ATTENDEEs in event" do
     event =
       """
       BEGIN:VEVENT
@@ -99,6 +99,21 @@ defmodule ICalendar.Util.DeserializeTest do
       |> String.split("\n")
       |> Deserialize.build_event()
 
-      assert %Event{} = event
+    assert %Event{} = event
+  end
+
+  test "Convert other time zone formats to UTC" do
+    event =
+      """
+      BEGIN:VEVENT
+      DTSTART;TZID=Greenwich Standard Time:20190726T190000
+      DTEND;TZID=Greenwich Standard Time:20190726T213000
+      END:VEVENT
+      """
+      |> String.trim()
+      |> String.split("\n")
+      |> Deserialize.build_event()
+
+    assert %Event{} = event
   end
 end

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -138,7 +138,7 @@ defmodule ICalendarTest do
       }
     ]
 
-    new_event =
+    [new_event] =
       %ICalendar{events: events}
       |> ICalendar.to_ics(vendor: @vendor)
       |> ICalendar.from_ics()


### PR DESCRIPTION
Current implementation deserializes only the last event in the calendar and returns the single event. This has to be a bug since an .ics file can contain any number of events.

I included some passing tests.

Some other improvements:

- support for empty keys 
```
 BEGIN:VEVENT
 DESCRIPTION:
 END:VEVENT
```

- support for date strings since this is common in Google calendar .ics links
```
BEGIN:VEVENT
DTSTART;VALUE=DATE:20190624
DTEND;VALUE=DATE:20190625
END:VEVENT
```