### PR TITLE
Serialize and deserialize ORGANIZER with params

### DIFF
--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -175,10 +175,10 @@ defmodule ICalendar.Util.Deserialize do
   end
 
   def parse_attr(
-        %Property{key: "ORGANIZER", params: _params, value: organizer},
+        %Property{key: "ORGANIZER", params: params, value: value},
         acc
       ) do
-    %{acc | organizer: organizer}
+    %{acc | organizer: Map.put(params, :original_value, value)}
   end
 
   def parse_attr(

--- a/lib/icalendar/util/kv.ex
+++ b/lib/icalendar/util/kv.ex
@@ -93,6 +93,15 @@ defmodule ICalendar.Util.KV do
     |> Enum.join("\n")
   end
 
+  def build("ORGANIZER", %{} = organizer) do
+    params =
+      for {key, val} <- organizer, key != :original_value, into: "" do
+        ";#{key}=#{val}"
+      end
+
+    "ORGANIZER#{params}:#{organizer.original_value}\n"
+  end
+
   def build(key, date = %DateTime{time_zone: "Etc/UTC"}) do
     "#{key}:#{Value.to_ics(date)}Z\n"
   end

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -74,36 +74,6 @@ defmodule ICalendar.Util.DeserializeTest do
     assert %Event{} = event
   end
 
-  @tag :skip
-  test "Include ORGANIZER and ATTENDEEs in event" do
-    event =
-      """
-      BEGIN:VEVENT
-      DTSTART:20190711T130000Z
-      DTEND:20190711T150000Z
-      DTSTAMP:20190719T195201Z
-      ORGANIZER;CN=paul@clockk.com:mailto:paul@clockk.com
-      UID:7E212264-C604-4071-892B-E0A28048F1BA
-      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=eric@clockk.com;X-NUM-GUESTS=0:mailto:eric@clockk.com
-      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=paul@clockk.com;X-NUM-GUESTS=0:mailto:paul@clockk.com
-      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=James SM;X-NUM-GUESTS=0:mailto:james@clockk.com
-      CREATED:20190709T192336Z
-      DESCRIPTION:
-      LAST-MODIFIED:20190711T130843Z
-      LOCATION:In-person at Volta and https://zoom.us/j/12345678
-      SEQUENCE:0
-      STATUS:CONFIRMED
-      SUMMARY:Design session
-      END:VEVENT
-      """
-      |> String.trim()
-      |> String.split("\n")
-      |> Deserialize.build_event()
-
-    assert %Event{} = event
-    assert event.organizer == "mailto:paul@clockk.com"
-  end
-
   test "Include ORGANIZER w/ params and ATTENDEEs in event" do
     event =
       """

--- a/test/icalendar/util/deserialize_test.exs
+++ b/test/icalendar/util/deserialize_test.exs
@@ -74,6 +74,7 @@ defmodule ICalendar.Util.DeserializeTest do
     assert %Event{} = event
   end
 
+  @tag :skip
   test "Include ORGANIZER and ATTENDEEs in event" do
     event =
       """
@@ -100,6 +101,36 @@ defmodule ICalendar.Util.DeserializeTest do
       |> Deserialize.build_event()
 
     assert %Event{} = event
+    assert event.organizer == "mailto:paul@clockk.com"
+  end
+
+  test "Include ORGANIZER w/ params and ATTENDEEs in event" do
+    event =
+      """
+      BEGIN:VEVENT
+      DTSTART:20190711T130000Z
+      DTEND:20190711T150000Z
+      DTSTAMP:20190719T195201Z
+      ORGANIZER;CN=paul@clockk.com:mailto:paul@clockk.com
+      UID:7E212264-C604-4071-892B-E0A28048F1BA
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=eric@clockk.com;X-NUM-GUESTS=0:mailto:eric@clockk.com
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=paul@clockk.com;X-NUM-GUESTS=0:mailto:paul@clockk.com
+      ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;CN=James SM;X-NUM-GUESTS=0:mailto:james@clockk.com
+      CREATED:20190709T192336Z
+      DESCRIPTION:
+      LAST-MODIFIED:20190711T130843Z
+      LOCATION:In-person at Volta and https://zoom.us/j/12345678
+      SEQUENCE:0
+      STATUS:CONFIRMED
+      SUMMARY:Design session
+      END:VEVENT
+      """
+      |> String.trim()
+      |> String.split("\n")
+      |> Deserialize.build_event()
+
+    assert %Event{organizer: organizer} = event
+    assert %{:original_value => "mailto:paul@clockk.com", "CN" => "paul@clockk.com"} = organizer
   end
 
   test "Convert other time zone formats to UTC" do


### PR DESCRIPTION
Closes #46 

This serializes and desializes `ORGANIZER` similar to how `ATTENDEE` works.

The only problem is that this is a breaking change for deserializing since it's now a `map` (like attendee) and not a `string`.

One way we could make deserializing _not_ a breaking change would be to pass in some "optional options" `opts \\ []`, but they'd have to be passed all the way through from:
`ICalendar.Deserialize.from_ics/1`
-> `ICalendar.Util.Deserialize.build_event/1`
-> `ICalendar.Util.Deserialize.parse_attrs/2`

What do you think we should do?