### PR TITLE
Add support for arbitrary calendar headers

### DIFF
--- a/lib/icalendar.ex
+++ b/lib/icalendar.ex
@@ -43,11 +43,16 @@ defimpl ICalendar.Serialize, for: ICalendar do
     events = Enum.map(calendar.events, &ICalendar.Serialize.to_ics/1)
     vendor = Keyword.get(options, :vendor, "Elixir ICalendar")
 
+    headers = options
+              |> Keyword.get(:headers, [])
+              |> Enum.map(fn({k,v}) -> "\n#{k}:#{v}" end)
+              |> Enum.join("\n")
+
     """
     BEGIN:VCALENDAR
     CALSCALE:GREGORIAN
     VERSION:2.0
-    PRODID:-//Elixir ICalendar//#{vendor}//EN
+    PRODID:-//Elixir ICalendar//#{vendor}//EN#{headers}
     #{events}END:VCALENDAR
     """
   end

--- a/lib/icalendar/serialize.ex
+++ b/lib/icalendar/serialize.ex
@@ -6,6 +6,8 @@ defprotocol ICalendar.Serialize do
 
     * `vendor` a string containing the vendor's name. Will produce
       `PRODID:-//ICalendar//My Name//EN`.
+    * `headers` a keyword list containing the headers to 
+      be placed in the  calendar header: `[{"Method", "Request"}]`
   """
   def to_ics(data, options \\ [])
 end

--- a/test/icalendar_test.exs
+++ b/test/icalendar_test.exs
@@ -27,6 +27,19 @@ defmodule ICalendarTest do
            """
   end
 
+  test "ICalendar.to_ics/1 of empty calendar with custom headers" do
+    ics = %ICalendar{} |> ICalendar.to_ics(headers: [{"METHOD", "REQUEST"}])
+
+    assert ics == """
+           BEGIN:VCALENDAR
+           CALSCALE:GREGORIAN
+           VERSION:2.0
+           PRODID:-//Elixir ICalendar//Elixir ICalendar//EN
+           METHOD:REQUEST
+           END:VCALENDAR
+           """
+  end
+
   test "ICalendar.to_ics/1 of a calendar with an event, as in README" do
     events = [
       %ICalendar.Event{


### PR DESCRIPTION
In order to get a calendar invite sent via email to show RSVP buttons, the ics file must contain a `METHOD` header which matches the method provided in the `Content-Type` header of its file attachment (See the first paragraph of the iMIP RFC: https://datatracker.ietf.org/doc/html/rfc6047#section-2.4) 

This can be achieved by inserting the headers manually after the ics has been generated, but this PR adds support for arbitrary headers to be added below the `PRODID` header.