### PR TITLE
Handle wrapped lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+- Handle calendars that wrap output such as Google Calendar
+
 ## v1.1.1 - 2021-12-26
 
 - Fixed a bug where newlines were incorrectly handled.

--- a/lib/icalendar/deserialize.ex
+++ b/lib/icalendar/deserialize.ex
@@ -10,10 +10,18 @@ defimpl ICalendar.Deserialize, for: BitString do
   def from_ics(ics) do
     ics
     |> String.trim()
+    |> adjust_wrapped_lines()
     |> String.split("\n")
     |> Enum.map(&String.trim_trailing/1)
     |> Enum.map(&String.replace(&1, ~S"\n", "\n"))
     |> get_events()
+  end
+
+  # Copy approach from Ruby library to deal with Google Calendar's wrapping
+  # https://github.com/icalendar/icalendar/blob/14db8fdd36f9007fa2627b2c10a9cdf3c9f8f35a/lib/icalendar/parser.rb#L9-L22
+  # See https://github.com/lpil/icalendar/issues/53 for discussion
+  defp adjust_wrapped_lines(body) do
+    String.replace(body, ~r/\r?\n[ \t]/, "")
   end
 
   defp get_events(calendar_data, event_collector \\ [], temp_collector \\ [])

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -36,6 +36,40 @@ defmodule ICalendar.DeserializeTest do
              }
     end
 
+    test "Single event with wrapped description and summary" do
+      ics = """
+      BEGIN:VEVENT
+      DESCRIPTION:Escape from the world. Stare at some water. Maybe you'll even
+        catch some fish!
+      COMMENT:Don't forget to take something to eat !
+      SUMMARY:Going fishing at the lake that happens to be in the middle of fun
+        street.
+      DTEND:20151224T084500Z
+      DTSTART:20151224T083000Z
+      LOCATION:123 Fun Street\\, Toronto ON\\, Canada
+      STATUS:TENTATIVE
+      CATEGORIES:Fishing,Nature
+      CLASS:PRIVATE
+      GEO:43.6978819;-79.3810277
+      END:VEVENT
+      """
+
+      [event] = ICalendar.from_ics(ics)
+
+      assert event == %Event{
+               dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
+               dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
+               summary: "Going fishing at the lake that happens to be in the middle of fun street.",
+               description: "Escape from the world. Stare at some water. Maybe you'll even catch some fish!",
+               location: "123 Fun Street, Toronto ON, Canada",
+               status: "tentative",
+               categories: ["Fishing", "Nature"],
+               comment: "Don't forget to take something to eat !",
+               class: "private",
+               geo: {43.6978819, -79.3810277}
+             }
+    end
+
     test "with Timezone" do
       ics = """
       BEGIN:VEVENT


### PR DESCRIPTION
Happens often for Google Calendar when a description or title is longer than the length that Google wraps the output at.

Fixes #53