### PR TITLE
Interpret Unrecognized Timezones as UTC

### DIFF
--- a/lib/icalendar/util/deserialize.ex
+++ b/lib/icalendar/util/deserialize.ex
@@ -236,12 +236,7 @@ defmodule ICalendar.Util.Deserialize do
   def to_date(date_string, %{"TZID" => timezone}) do
     # Microsoft Outlook calendar .ICS files report times in Greenwich Standard Time (UTC +0)
     # so just convert this to UTC
-    timezone =
-      if Regex.match?(~r/\//, timezone) do
-        timezone
-      else
-        Timex.Timezone.Utils.to_olson(timezone)
-      end
+    timezone = parse_timezone(timezone)
 
     date_string =
       case String.last(date_string) do
@@ -262,6 +257,21 @@ defmodule ICalendar.Util.Deserialize do
 
   def to_date(date_string) do
     to_date(date_string, %{"TZID" => "Etc/UTC"})
+  end
+
+  defp parse_timezone(timezone) do
+    tz =
+      if Regex.match?(~r/\//, timezone) do
+        timezone
+      else
+        Timex.Timezone.Utils.to_olson(timezone)
+      end
+
+    if is_nil(tz) do
+      "Etc/UTC"
+    else
+      tz
+    end
   end
 
   defp to_geo(geo) do

--- a/test/icalendar/deserialize_test.exs
+++ b/test/icalendar/deserialize_test.exs
@@ -85,6 +85,19 @@ defmodule ICalendar.DeserializeTest do
       assert event.dtend.time_zone == "America/Chicago"
     end
 
+    test "with unrecognized Timezone" do
+      ics = """
+      BEGIN:VEVENT
+      DTEND;TZID=GMT-0500:22221224T084500
+      DTSTART;TZID=GMT-0500:22221224T083000
+      END:VEVENT
+      """
+
+      [event] = ICalendar.from_ics(ics)
+      assert event.dtstart.time_zone == "Etc/UTC"
+      assert event.dtend.time_zone == "Etc/UTC"
+    end
+
     test "with CR+LF line endings" do
       ics = """
       BEGIN:VEVENT


### PR DESCRIPTION
The current implementation raises an error if any event in the ICS has an unrecognized timezone. For example, some calendaring apps use (or have used in the past) GMT offset formatting such as `GMT-0500`. Rather than raise the error, this change would make the tradeoff that the timezone would "guess" UTC.

Longer term, it would probably be worth the effort to add support for these misc. timezone formats rather than interpret them all as UTC.